### PR TITLE
Enable http logging only in Debug variant

### DIFF
--- a/app/src/main/java/com/esoxjem/movieguide/network/NetworkModule.java
+++ b/app/src/main/java/com/esoxjem/movieguide/network/NetworkModule.java
@@ -33,14 +33,17 @@ public class NetworkModule {
     @Provides
     @Singleton
     OkHttpClient provideOkHttpClient(RequestInterceptor requestInterceptor) {
-        HttpLoggingInterceptor loggingInterceptor = new HttpLoggingInterceptor();
-        loggingInterceptor.setLevel(HttpLoggingInterceptor.Level.BODY);
+        OkHttpClient.Builder builder = new OkHttpClient.Builder();
+        builder.connectTimeout(CONNECT_TIMEOUT_IN_MS, TimeUnit.MILLISECONDS)
+                .addInterceptor(requestInterceptor);
 
-        return new okhttp3.OkHttpClient.Builder()
-                .connectTimeout(CONNECT_TIMEOUT_IN_MS, TimeUnit.MILLISECONDS)
-                .addInterceptor(loggingInterceptor)
-                .addInterceptor(requestInterceptor)
-                .build();
+        if (BuildConfig.DEBUG) {
+            HttpLoggingInterceptor loggingInterceptor = new HttpLoggingInterceptor();
+            loggingInterceptor.setLevel(HttpLoggingInterceptor.Level.BODY);
+            builder.addInterceptor(loggingInterceptor);
+        }
+
+        return builder.build();
     }
 
     @Singleton


### PR DESCRIPTION
Add logging interceptor to OkHttp client only in Debug variant, in Release, the logging must not be activated.