### PR TITLE
Restore data when comming back to app

### DIFF
--- a/app/src/main/java/com/esoxjem/movieguide/listing/MoviesListingFragment.java
+++ b/app/src/main/java/com/esoxjem/movieguide/listing/MoviesListingFragment.java
@@ -167,6 +167,12 @@ public class MoviesListingFragment extends Fragment implements MoviesListingView
     }
 
     @Override
+    public void onResume() {
+        super.onResume();
+        initLayoutReferences();
+    }
+
+    @Override
     public void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
         outState.putParcelableArrayList(Constants.MOVIE, (ArrayList<? extends Parcelable>) movies);


### PR DESCRIPTION
I enable the '_don't keep the activities_' option and i saw that when i come back to the app, the data is empty so I thought about it and I implemented the method 'OnResume' to take control about the activity's lifecycle and inside this method I call the method '_initLayoutReferences_'. This method is used to populate the ArrayList with data.

Hope this solution it is good!.
Thanks!.